### PR TITLE
[Fix] 칸반 스토어 actions 분리

### DIFF
--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -5,7 +5,7 @@ import useKanbanStore from '@/stores/kanban-store'
 import Button from '../ui/button'
 
 const SideBar = () => {
-  const { addKanban, resetKanban } = useKanbanStore((state) => state)
+  const { addKanban, resetKanban } = useKanbanStore((state) => state.actions)
 
   return (
     <aside className="relative h-full w-[100px]">

--- a/components/ui/kanban-card.tsx
+++ b/components/ui/kanban-card.tsx
@@ -21,7 +21,9 @@ interface Props {
 const KanbanCard = ({ index, kanban }: Props) => {
   const kanbanRef = useRef<HTMLLIElement>(null)
   const kanbanList = useKanbanStore((state) => state.kanbanList)
-  const { updateKanban, deleteKanban, setDraggedKanbanList } = useKanbanStore((state) => state)
+  const { updateKanban, deleteKanban, setDraggedKanbanList } = useKanbanStore(
+    (state) => state.actions,
+  )
   const { kanbanId, title, description, createdAt, todoList, inProgressList, doneList } = kanban
 
   // 'kanban' type인 Drag and Drop 설정, drop 시 핸들러 실행

--- a/components/ui/task-card.tsx
+++ b/components/ui/task-card.tsx
@@ -18,7 +18,7 @@ const TASK_LABEL: { [key in TaskStatusType]: TaskLabelType } = {
 }
 
 const TaskCard = ({ status, kanbanId, children }: Props) => {
-  const addTask = useKanbanStore((state) => state.addTask)
+  const addTask = useKanbanStore((state) => state.actions.addTask)
 
   return (
     <div className="bg-gray-500 rounded-md p-[20px] flex flex-col gap-2">

--- a/components/ui/task.tsx
+++ b/components/ui/task.tsx
@@ -21,7 +21,9 @@ interface Props {
 const Task = ({ task, index, kanbanId, status }: Props) => {
   const taskRef = useRef<HTMLLIElement>(null)
   const kanbanList = useKanbanStore((state) => state.kanbanList)
-  const { updateTask, deleteTask, addTask, setDraggedKanbanList } = useKanbanStore((state) => state)
+  const { updateTask, deleteTask, addTask, setDraggedKanbanList } = useKanbanStore(
+    (state) => state.actions,
+  )
 
   // 'task' type인 Drag and Drop 설정, drop 시 핸들러 실행
   const [, drop] = useDrop({

--- a/stores/kanban-store.tsx
+++ b/stores/kanban-store.tsx
@@ -8,14 +8,16 @@ interface StateModel {
 }
 
 interface ActionsModel {
-  addKanban: () => void
-  updateKanban: (id: string, key: 'title' | 'description', value: string) => void
-  deleteKanban: (id: string) => void
-  setDraggedKanbanList: (list: KanbanModel[]) => void
-  addTask: (kanbanId: string, status: TaskStatusType) => void
-  updateTask: (kanbanId: string, status: TaskStatusType, taskId: string, value: string) => void
-  deleteTask: (kanbanId: string, taskId: string, status: TaskStatusType) => void
-  resetKanban: () => void
+  actions: {
+    addKanban: () => void
+    updateKanban: (id: string, key: 'title' | 'description', value: string) => void
+    deleteKanban: (id: string) => void
+    setDraggedKanbanList: (list: KanbanModel[]) => void
+    addTask: (kanbanId: string, status: TaskStatusType) => void
+    updateTask: (kanbanId: string, status: TaskStatusType, taskId: string, value: string) => void
+    deleteTask: (kanbanId: string, taskId: string, status: TaskStatusType) => void
+    resetKanban: () => void
+  }
 }
 
 const initialState: StateModel = {
@@ -38,117 +40,107 @@ const initialState: StateModel = {
   ],
 }
 
-const useKanbanStore = create(
-  persist<StateModel & ActionsModel>(
+const useKanbanStore = create<StateModel & ActionsModel>()(
+  persist(
     (set) => ({
       ...initialState,
+      actions: {
+        // 칸반 추가
+        addKanban: () => {
+          set((state) => ({
+            kanbanList: [
+              {
+                kanbanId: uuidv4(),
+                title: '',
+                description: '',
+                createdAt: new Date()
+                  .toLocaleDateString('ko-KR', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                  })
+                  .slice(0, -1),
+                todoList: [],
+                inProgressList: [],
+                doneList: [],
+              },
+              ...state.kanbanList,
+            ],
+          }))
+        },
 
-      // 칸반 추가
-      addKanban: () => {
-        set((state) => ({
-          kanbanList: [
-            {
-              kanbanId: uuidv4(),
-              title: '',
-              description: '',
-              createdAt: new Date()
-                .toLocaleDateString('ko-KR', {
-                  year: 'numeric',
-                  month: '2-digit',
-                  day: '2-digit',
-                })
-                .slice(0, -1),
-              todoList: [],
-              inProgressList: [],
-              doneList: [],
-            },
-            ...state.kanbanList,
-          ],
-        }))
-      },
+        // 칸반 title, description 업데이트
+        updateKanban: (id: string, key: 'title' | 'description', value: string) => {
+          set((state) => ({
+            kanbanList: state.kanbanList.map((kanban) =>
+              kanban.kanbanId === id ? { ...kanban, [key]: value } : kanban,
+            ),
+          }))
+        },
 
-      // 칸반 title, description 업데이트
-      updateKanban: (id: string, key: 'title' | 'description', value: string) => {
-        set((state) => ({
-          kanbanList: state.kanbanList.map((kanban) =>
-            kanban.kanbanId === id ? { ...kanban, [key]: value } : kanban,
-          ),
-        }))
-      },
+        // 칸반 삭제
+        deleteKanban: (id: string) => {
+          set((state) => ({
+            kanbanList: state.kanbanList.filter((kanban) => kanban.kanbanId !== id),
+          }))
+        },
 
-      // 칸반 삭제
-      deleteKanban: (id: string) => {
-        set((state) => ({
-          kanbanList: state.kanbanList.filter((kanban) => kanban.kanbanId !== id),
-        }))
-      },
+        // Drag and Drop 이후 칸반 상태 업데이트
+        setDraggedKanbanList: (list: KanbanModel[]) => {
+          set(() => ({ kanbanList: list }))
+        },
 
-      // Drag and Drop 이후 칸반 상태 업데이트
-      setDraggedKanbanList: (list: KanbanModel[]) => {
-        set(() => ({ kanbanList: list }))
-      },
+        // 타스크 추가
+        addTask: (kanbanId: string, status: TaskStatusType) => {
+          set((state) => ({
+            kanbanList: state.kanbanList.map((kanban) =>
+              kanban.kanbanId === kanbanId
+                ? {
+                    ...kanban,
+                    [status]: [...kanban[status], { kanbanId, taskId: uuidv4(), description: '' }],
+                  }
+                : kanban,
+            ),
+          }))
+        },
 
-      // 타스크 추가
-      addTask: (kanbanId: string, status: TaskStatusType) => {
-        set((state) => ({
-          kanbanList: state.kanbanList.map((kanban) =>
-            kanban.kanbanId === kanbanId
-              ? {
-                  ...kanban,
-                  [status]: [...kanban[status], { kanbanId, taskId: uuidv4(), description: '' }],
-                }
-              : kanban,
-          ),
-        }))
-      },
+        // 타스트 description 업데이트
+        updateTask: (kanbanId: string, status: TaskStatusType, taskId: string, value: string) => {
+          set((state) => ({
+            kanbanList: state.kanbanList.map((kanban) =>
+              kanban.kanbanId === kanbanId
+                ? {
+                    ...kanban,
+                    [status]: kanban[status].map((task) =>
+                      task.taskId === taskId ? { ...task, description: value } : task,
+                    ),
+                  }
+                : kanban,
+            ),
+          }))
+        },
 
-      // 타스트 description 업데이트
-      updateTask: (kanbanId: string, status: TaskStatusType, taskId: string, value: string) => {
-        set((state) => ({
-          kanbanList: state.kanbanList.map((kanban) =>
-            kanban.kanbanId === kanbanId
-              ? {
-                  ...kanban,
-                  [status]: kanban[status].map((task) =>
-                    task.taskId === taskId ? { ...task, description: value } : task,
-                  ),
-                }
-              : kanban,
-          ),
-        }))
-      },
+        // 타스트 삭제
+        deleteTask: (kanbanId: string, taskId: string, status: TaskStatusType) => {
+          set((state) => ({
+            kanbanList: state.kanbanList.map((kanban) =>
+              kanban.kanbanId === kanbanId
+                ? {
+                    ...kanban,
+                    [status]: kanban[status].filter((task) => task.taskId !== taskId),
+                  }
+                : kanban,
+            ),
+          }))
+        },
 
-      // 타스트 삭제
-      deleteTask: (kanbanId: string, taskId: string, status: TaskStatusType) => {
-        set((state) => ({
-          kanbanList: state.kanbanList.map((kanban) =>
-            kanban.kanbanId === kanbanId
-              ? {
-                  ...kanban,
-                  [status]: kanban[status].filter((task) => task.taskId !== taskId),
-                }
-              : kanban,
-          ),
-        }))
-      },
-
-      // 상태 초기화
-      resetKanban: () => {
-        set((state) => ({
-          ...initialState,
-          addKanban: state.addKanban,
-          updateKanban: state.updateKanban,
-          deleteKanban: state.deleteKanban,
-          setDraggedKanbanList: state.setDraggedKanbanList,
-          addTask: state.addTask,
-          updateTask: state.updateTask,
-          deleteTask: state.deleteTask,
-          resetKanban: state.resetKanban,
-        }))
+        // 상태 초기화
+        resetKanban: () => set({ ...initialState }),
       },
     }),
     {
       name: 'kanban-store',
+      partialize: (state) => ({ kanbanList: state.kanbanList }),
     },
   ),
 )


### PR DESCRIPTION
state, action 분리 -> 컴포넌트에서도 분리하여 가져올 수 있도록 

기존엔 미들웨어에 스토어 상태 타입을 명시해두었고 미들웨어 내부에서 actions로 분리하면 로컬스토리지에 저장되는 상태 구조가 달라 컴포넌트에서 액션함수를 불러올 수 없었음. 이를 미들웨어가 아닌 스토어에 타입을 명시하고 partialize 옵션으로 로컬스토리지에 액션을 제외한 상태만 저장되도록하여 actions로 분리했을 때 컴포넌트에서도 잘 가져올 수 있도록 함.